### PR TITLE
Correct misspelled "class" attribute in system.xml

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -13,7 +13,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <tab id="celebros" translate="label" sortOrder="200000" calss="celebros-tab">
+        <tab id="celebros" translate="label" sortOrder="200000" class="celebros-tab">
             <label></label>
         </tab>
         <section id="conversionpro" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="1">


### PR DESCRIPTION
This issue prevents from using Store -> Configuration section of admin panel.

Exception #0 (Magento\Framework\Exception\LocalizedException): The XML in file "{project_root}/vendor/celebros/module-conversionpro/etc/adminhtml/system.xml" is invalid:
Element 'tab', attribute 'calss': The attribute 'calss' is not allowed.
Line: 16

Verify the XML and try again.